### PR TITLE
[feature] SSL/TLS self-cert no-verify override

### DIFF
--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -20,7 +20,11 @@ impl Beacon {
 	pub fn new(model: Option<Model>, framework: Framework, url: &Url) -> Result<Self, VerifierError> {
 		let mut info_url = url.clone();
 		info_url.set_path(Path::new(url.path()).join("info").to_str().unwrap_or(""));
-		let info: Json = reqwest::blocking::get(&info_url.to_string())?.json().unwrap();
+                // switch to builder to allow ignore self-signed ssl certs
+                let info_builder = reqwest::blocking::Client::builder()
+                    .danger_accept_invalid_certs(true) // make setting
+                    .build()?;               
+		let info: Json = info_builder.get(&info_url.to_string()).send()?.json().unwrap();
 		log::trace!("{}", info);
 
 		Ok(Self {

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -9,6 +9,8 @@ use crate::model::Model;
 use crate::output::{BeaconOutput, EndpointReport, Output};
 use crate::{utils, Json};
 
+use clap::Parser;
+
 pub struct Beacon {
 	name: String,
 	url: Url,
@@ -20,11 +22,13 @@ impl Beacon {
 	pub fn new(model: Option<Model>, framework: Framework, url: &Url) -> Result<Self, VerifierError> {
 		let mut info_url = url.clone();
 		info_url.set_path(Path::new(url.path()).join("info").to_str().unwrap_or(""));
+
                 // switch to builder to allow ignore self-signed ssl certs
-                let info_builder = reqwest::blocking::Client::builder()
-                    .danger_accept_invalid_certs(true) // make setting
+                let matches = crate::Args::parse();
+                let client = reqwest::blocking::Client::builder()
+                    .danger_accept_invalid_certs(matches.ssl_no_verify)
                     .build()?;               
-		let info: Json = info_builder.get(&info_url.to_string()).send()?.json().unwrap();
+		let info: Json = client.get(&info_url.to_string()).send()?.json().unwrap();
 		log::trace!("{}", info);
 
 		Ok(Self {

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -27,7 +27,7 @@ impl Beacon {
                 let matches = crate::Args::parse();
                 let client = reqwest::blocking::Client::builder()
                     .danger_accept_invalid_certs(matches.ssl_no_verify)
-                    .build()?;               
+                    .build()?;
 		let info: Json = client.get(&info_url.to_string()).send()?.json().unwrap();
 		log::trace!("{}", info);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ struct Args {
 
 	/// Url to the Beacon implementation
 	url: Url,
+
+        /// Skip tls/ssl cert validation
+        #[clap(long = "ssl-no-verify")]
+        ssl_no_verify: bool,
 }
 
 fn main() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,7 +60,9 @@ pub fn copy_dir_recursively<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> R
 
 pub fn ping_url(endpoint_url: &Url) -> Result<Json, VerifierError> {
 	// Query endpoint
-	let client = reqwest::blocking::Client::new();
+        let client = reqwest::blocking::Client::builder()
+            .danger_accept_invalid_certs(true) // make setting
+            .build()?;               
 
 	let response = match client.get(endpoint_url.clone()).send() {
 		Ok(response) if response.status().is_success() => response,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,7 +66,7 @@ pub fn ping_url(endpoint_url: &Url) -> Result<Json, VerifierError> {
         // Build client
         let client = reqwest::blocking::Client::builder()
             .danger_accept_invalid_certs(matches.ssl_no_verify)
-            .build()?;               
+            .build()?;
 
 	// Query endpoint
 	let response = match client.get(endpoint_url.clone()).send() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,8 @@ use crate::interface::{BeaconResultSetResponse, EntityResult};
 // use crate::interface::FilteringTerm;
 use crate::{error, Json};
 
+use clap::Parser;
+
 pub fn copy_dir_recursively<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> Result<(), VerifierError> {
 	let mut stack = vec![PathBuf::from(from.as_ref())];
 
@@ -59,11 +61,14 @@ pub fn copy_dir_recursively<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> R
 }
 
 pub fn ping_url(endpoint_url: &Url) -> Result<Json, VerifierError> {
-	// Query endpoint
+
+        let matches = crate::Args::parse();
+        // Build client
         let client = reqwest::blocking::Client::builder()
-            .danger_accept_invalid_certs(true) // make setting
+            .danger_accept_invalid_certs(matches.ssl_no_verify)
             .build()?;               
 
+	// Query endpoint
 	let response = match client.get(endpoint_url.clone()).send() {
 		Ok(response) if response.status().is_success() => response,
 		Ok(response) => {


### PR DESCRIPTION
Hello there :)

I've been using the tool (thanks!) to test against a work-in-progress beacon-v2 implementation.
The implementation has moved to a point where it now uses self-signed ssl/tls certificates to provide access over the https protocol.  AFAICT, the verifier (main@2301d5e) doesn't currently support this, e.g.,

`beacon-verifier https://10.128.0.3:9001 2>&1`

```
 INFO  beacon_verifier > Valid spec (number of entities: 7)
 INFO  beacon_verifier > Validating implementation on https://10.128.0.3:9001/
{
  "name": "Unknown Beacon (Request error error sending request for url (https://10.128.0.3:9001/info): error trying to connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1913: (self signed certificate))",
  "url": "https://10.128.0.3:9001/",
  "last_updated": "2022-09-12T16:32:42.030473",
  "entities": {}
}
```

I've forked the code and added a new command-line flag ('ssl-no-verify') + the required functionality.
and seem to have it working again:

`beacon-verifier --ssl-no-verify https://10.128.0.3:9001 2>/dev/null | jq '.entities.Info'`

```
[
  {
    "name": "Inst-Dept Beacon",
    "url": "https://10.128.0.3:9001/info",
    "valid": true,
    "error": null
  }
]
```

I haven't really tested it beyond the fact that it passes the original ssl error above, but it currently works for my purposes :)

---
I wanted to share the code incase it might also be useful to you folks.

Again, thanks,
Joe.